### PR TITLE
Add OSSRH snapshot repository

### DIFF
--- a/settings.xml
+++ b/settings.xml
@@ -17,6 +17,20 @@
 				<!-- Load passphrase from env variable -->
 				<gpg.passphrase>${env.INPUT_GPG_PASSPHRASE}</gpg.passphrase>
 			</properties>
+			
+			<repositories>
+        <repository>
+          <id>maven-snapshots</id>
+          <url>http://oss.sonatype.org/content/repositories/snapshots</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>false</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
 		</profile>
 	</profiles>
 


### PR DESCRIPTION
Thanks for this action. It really helped simplify deployment to Maven central for me.

Usually when deploying to Maven central via OSSRH, you will also be deploying to the OSSRH snapshot repository.

It's convenient to add this repository to your local settings.xml, instead of the pom.xml, when you are managing many repositories, to avoid duplication.

I think that since this action overwrites the settings.xml, the only way to achieve this when using this action is for it to be added to this action.