### PR TITLE
Suggest using auth token for Nexus instead of username/password

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Make sure your project is correctly configured for deployment before continuing 
 In your project's GitHub repository, go to Settings → Secrets. On this page, set the following variables:
 
 - `nexus_username`: Username (not email!) for your Nexus repository manager account
-- `nexus_password`: Password for your Nexus account
+- `nexus_password`: Password for your Nexus account (or, even better, use the [auth token](https://solidsoft.wordpress.com/2015/09/08/deploy-to-maven-central-using-api-key-aka-auth-token/) instead)
 
 Signing your artifact using GPG is optional, but recommended. If you choose to use GPG, add the following secrets:
 


### PR DESCRIPTION
It is safer, as with the auth token it should be not possible to change your password in Nexus.

I linked my old blog post explaining how to do that.