### PR TITLE
Only add "active-profiles" parameter, if one exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,6 @@ function runAction() {
 
 	const mavenArgs = getInput("maven_args", true);
 	const mavenGoalsPhases = getInput("maven_goals_phases", true);
-	const mavenProfiles = getInput("maven_profiles", true);
 
 	// Import GPG key into keychain
 	const privateKey = getInput("gpg_private_key").trim();
@@ -76,12 +75,17 @@ function runAction() {
 		unlinkSync(gpgKeyPath);
 	}
 
+	let mavenProfiles = getInput("maven_profiles", true).trim();
+	if (mavenProfiles) {
+		mavenProfiles = `--activate-profiles ${mavenProfiles}`;
+	}
+
 	// Deploy to Nexus
 	// The "deploy" profile is used in case the user wants to perform certain steps only during
 	// deployment and not in the install phase
 	log("Deploying the Maven project…");
 	run(
-		`mvn ${mavenGoalsPhases} --batch-mode --activate-profiles ${mavenProfiles} --settings ${mavenSettingsPath} ${mavenArgs}`,
+		`mvn ${mavenGoalsPhases} --batch-mode ${mavenProfiles} --settings ${mavenSettingsPath} ${mavenArgs}`,
 		getInput("directory") || null,
 	);
 }


### PR DESCRIPTION
Hi, back in 2020 I created an [enhancement-request](https://github.com/samuelmeuli/action-maven-publish/issues/12) to allow omitting a maven-profile in the deploy-command
@XDean then went ahead and implemented that, huge thanks for that by the way :) 
However, my build-plan still crashes if the maven-profile is omitted, since the '--activate-profiles'-parameter is still present and is missing a value.

To fix this I added a condition that only adds that parameter, if the profile-parameter is not empty.
I am already using that fixed version in my project and it works for me 👍 
